### PR TITLE
use lease endpoint-reconciler for apiserver endpoints

### DIFF
--- a/kubernetes/files/manifest/kube-apiserver.manifest
+++ b/kubernetes/files/manifest/kube-apiserver.manifest
@@ -42,13 +42,17 @@ spec:
       {%- if master.auth.get('token', {}).enabled|default(True) %}
       --token-auth-file={{ master.auth.token.file|default("/srv/kubernetes/known_tokens.csv") }}
       {%- endif %}
-      --apiserver-count={{ master.apiserver.get('count', 1) }}
       --etcd-quorum-read=true
       --v={{ master.get('verbosity', 2) }}
       --allow-privileged=True
       {%- if common.addons.get('virtlet', {}).get('enabled') %}
       {%- if version|float >= 1.8 %}
         --feature-gates=MountPropagation=true
+      {%- endif %}
+      {%- if version|float >= 1.9 %}
+      --endpoint-reconciler-type={{ master.apiserver.get('endpoint-reconciler', 'lease') }}
+      {%- else %}
+      --apiserver-count={{ master.apiserver.get('count', 1) }}
       {%- endif %}
       {%- endif %}
       {%- if master.auth.get('mode') %}

--- a/kubernetes/master/controller.sls
+++ b/kubernetes/master/controller.sls
@@ -123,7 +123,6 @@ kubernetes_basic_auth:
         {%- if master.auth.get('token', {}).enabled|default(True) %}
         --token-auth-file={{ master.auth.token.file|default("/srv/kubernetes/known_tokens.csv") }}
         {%- endif %}
-        --apiserver-count={{ master.apiserver.get('count', 1) }}
         --v={{ master.get('verbosity', 2) }}
         --advertise-address={{ master.apiserver.address }}
         --etcd-servers=
@@ -148,6 +147,12 @@ kubernetes_basic_auth:
 {%- if version|float >= 1.8 %}
         --feature-gates=MountPropagation=true
 {%- endif %}
+{%- if version|float >= 1.9 %}
+        --endpoint-reconciler-type={{ master.apiserver.get('endpoint-reconciler', 'lease') }}
+{%- else %}
+        --apiserver-count={{ master.apiserver.get('count', 1) }}
+{%- endif %}
+
 {%- endif %}
 {%- for key, value in master.get('apiserver', {}).get('daemon_opts', {}).items() %}
         --{{ key }}={{ value }}


### PR DESCRIPTION
This option allows apiservers to manage endpoints fot itself by leases.

see https://kubernetes.io/docs/admin/high-availability/building/#endpoint-reconciler

cc @epcim @cznewt 