### PR TITLE
fix calico CNI nodename detection

### DIFF
--- a/kubernetes/files/calico/calico-node.service.master
+++ b/kubernetes/files/calico/calico-node.service.master
@@ -29,6 +29,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -p {{ pool.network.calico.prometheus.get('address', '0.0.0.0') }}:{{ master.network.calico.get('prometheus', {}).get('port', 9091) }}:9091 \
 {%- endif %}
  -v /var/log/calico:/var/log/calico \
+ -v /var/lib/calico:/var/lib/calico \
  -v /run/docker/plugins:/run/docker/plugins \
  -v /lib/modules:/lib/modules \
  -v /var/run/calico:/var/run/calico \

--- a/kubernetes/files/calico/calico-node.service.pool
+++ b/kubernetes/files/calico/calico-node.service.pool
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -p {{ pool.network.calico.prometheus.get('address', '0.0.0.0') }}:{{ pool.network.calico.prometheus.get('port', 9091) }}:9091 \
 {%- endif %}
  -v /var/log/calico:/var/log/calico \
+ -v /var/lib/calico:/var/lib/calico \
  -v /run/docker/plugins:/run/docker/plugins \
  -v /lib/modules:/lib/modules \
  -v /var/run/calico:/var/run/calico \


### PR DESCRIPTION
It's required to mount `/var/lib/calico` into node container because file in this directory is used for nodename detection.

see https://github.com/projectcalico/cni-plugin/blob/master/calico.go#L59